### PR TITLE
Fix CP validation

### DIFF
--- a/fioul/urls.py
+++ b/fioul/urls.py
@@ -87,6 +87,7 @@ urlpatterns += [
         distrib_hp,
         name="distrib-hp",
     ),
+    url(r"^distributeur/", admin.site.urls),
 ]
 
 # Interface client

--- a/fioulexpress/views.py
+++ b/fioulexpress/views.py
@@ -687,7 +687,7 @@ def client_valide_cp(request):
         or not code_postal.zone.distributeur.actif
     ):
         msg = render_to_string(
-            "commande/prospect_inscription_form.html", RequestContext(request)
+            "commande/prospect_inscription_form.html", request=request
         )
         messages.add_message(request, messages.INFO, msg)
         return redirect("/")


### PR DESCRIPTION
add distributeur url

In Django 1.8+, the template's render method takes a dictionary for the context parameter. Support for passing a Context instance is deprecated, and gives an error in Django 1.10+.